### PR TITLE
upgrade dep 'jts-core' to 1.16.1

### DIFF
--- a/MeteoInfoLib/pom.xml
+++ b/MeteoInfoLib/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
-            <version>1.15.1</version>
+            <version>1.16.1</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
We should upgrade version of `jts-core` >= `1.16`, or maven would complain `CoordinateXYM is missing`.

`org.locationtech.jts.geom.CoordinateXYM` is since 1.16, see [link](https://github.com/locationtech/jts/commits/590d48fa4d8b15aec71b4540de962ae49feb365a/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXYM.java).
